### PR TITLE
Observe when an app has been upgraded as well as first launch.

### DIFF
--- a/Example/RxAppState_ExampleTests/RxAppStateTests.swift
+++ b/Example/RxAppState_ExampleTests/RxAppStateTests.swift
@@ -120,7 +120,7 @@ class RxAppStateTests: XCTestCase {
         XCTAssertEqual(firstLaunchArray, [true])
     }
     
-    func testisFirstLaunchOfNewVersionNewInstall() {
+    func testIsFirstLaunchOfNewVersionNewInstall() {
         // Given
         var firstLaunchArray: [Bool] = []
         application.rx.isFirstLaunchOfNewVersion
@@ -136,12 +136,12 @@ class RxAppStateTests: XCTestCase {
         XCTAssertEqual(firstLaunchArray, [false, false, false])
     }
     
-    func testisFirstLaunchOfNewVersionUpdate() {
+    func testIsFirstLaunchOfNewVersionUpdate() {
         // Given
         var firstLaunchArray: [Bool] = []
         UserDefaults.standard.set("3.2", forKey: self.lastAppVersionKey)
         UserDefaults.standard.synchronize()
-        RxAppState.getCurrentAppVersion = { _ in return "4.2" }
+        RxAppState.currentAppVersion = "4.2"
         
         application.rx.isFirstLaunchOfNewVersion
             .subscribe(onNext: { isFirstLaunchOfNewVersion in
@@ -157,12 +157,12 @@ class RxAppStateTests: XCTestCase {
         
     }
     
-    func testisFirstLaunchOfNewVersionExisting() {
+    func testIsFirstLaunchOfNewVersionExisting() {
         // Given
         var firstLaunchArray: [Bool] = []
         UserDefaults.standard.set("4.2", forKey: self.lastAppVersionKey)
         UserDefaults.standard.synchronize()
-        RxAppState.getCurrentAppVersion = { _ in return "4.2" }
+        RxAppState.currentAppVersion = "4.2"
         
         application.rx.isFirstLaunchOfNewVersion
             .subscribe(onNext: { isFirstLaunchOfNewVersion in
@@ -177,7 +177,7 @@ class RxAppStateTests: XCTestCase {
         XCTAssertEqual(firstLaunchArray, [false, false, false])
     }
     
-    func testfirstLaunchOfNewVersionOnlyNewInstall() {
+    func testFirstLaunchOfNewVersionOnlyNewInstall() {
         // Given
         var firstLaunchArray: [Bool] = []
         application.rx.firstLaunchOfNewVersionOnly
@@ -193,12 +193,12 @@ class RxAppStateTests: XCTestCase {
         XCTAssertEqual(firstLaunchArray, [])
     }
     
-    func testfirstLaunchOfNewVersionOnlyNewUpdate() {
+    func testFirstLaunchOfNewVersionOnlyNewUpdate() {
         // Given
         var firstLaunchArray: [Bool] = []
         UserDefaults.standard.set("3.2", forKey: self.lastAppVersionKey)
         UserDefaults.standard.synchronize()
-        RxAppState.getCurrentAppVersion = { _ in return "4.2" }
+        RxAppState.currentAppVersion = "4.2"
         
         application.rx.firstLaunchOfNewVersionOnly
             .subscribe(onNext: { _ in
@@ -213,12 +213,12 @@ class RxAppStateTests: XCTestCase {
         XCTAssertEqual(firstLaunchArray, [true])
     }
     
-    func testfirstLaunchOfNewVersionOnlyExisting() {
+    func testFirstLaunchOfNewVersionOnlyExisting() {
         // Given
         var firstLaunchArray: [Bool] = []
         UserDefaults.standard.set("4.2", forKey: self.lastAppVersionKey)
         UserDefaults.standard.synchronize()
-        RxAppState.getCurrentAppVersion = { _ in return "4.2" }
+        RxAppState.currentAppVersion = "4.2"
         
         application.rx.firstLaunchOfNewVersionOnly
             .subscribe(onNext: { _ in

--- a/Pod/Classes/UIApplication+Rx.swift
+++ b/Pod/Classes/UIApplication+Rx.swift
@@ -59,8 +59,7 @@ public struct RxAppState {
      Allows for the app version to be stored by default in the main bundle from `CFBundleShortVersionString` or
      a custom implementation per app.
      */
-    public static var getCurrentAppVersion: ((Void) -> String?) = { _ in return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String}
-
+    public static var currentAppVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
 }
 
 extension RxSwift.Reactive where Base: UIApplication {
@@ -78,12 +77,8 @@ extension RxSwift.Reactive where Base: UIApplication {
      */
     fileprivate var appVersions: (last: String, current: String) {
         return (last: UserDefaults.standard.string(forKey: self.lastAppVersionKey) ?? "",
-                current: RxAppState.getCurrentAppVersion() ?? "")
+                current: RxAppState.currentAppVersion ?? "")
     }
-    
-//    public static func getCurrentAppVersion(_ handler: ((Void) -> String?) = { _ in return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String}) -> String? {
-//        return handler()
-//    }
     
     /**
      Reactive wrapper for `delegate`.


### PR DESCRIPTION
In addition to the first launch then it’s useful to know if an app has been upgraded to present some extra information to the user or to remind them about signing up etc.

This was something we wanted as well as knowing the first ever launch so I’ve added it in.

The app version is injectable. Not only for testing but if the user wants a custom way of reporting that information. A fully usable default is provided.

Tests have also been added for the new functionality.
