### PR TITLE
 Remove unnecessary (as of Swift 4.1) equatable implementation

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ DEPENDENCIES:
   - RxSwift
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - RxCocoa
     - RxSwift
 
@@ -27,4 +27,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: db7af95ffeabefa6bd0633f84d15e84f95f0ace5
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.5.0

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -12,7 +12,7 @@ DEPENDENCIES:
   - RxSwift
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - RxCocoa
     - RxSwift
 
@@ -27,4 +27,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: db7af95ffeabefa6bd0633f84d15e84f95f0ace5
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.5.0

--- a/Pod/Classes/UIApplication+Rx.swift
+++ b/Pod/Classes/UIApplication+Rx.swift
@@ -66,18 +66,6 @@ public enum AppState: Equatable {
      The application is about to be terminated by the system
      */
     case terminated
-    
-    public static func ==(lhs: AppState, rhs: AppState) -> Bool {
-        switch (lhs, rhs) {
-        case (.active, .active),
-             (.inactive, .inactive),
-             (.background, .background),
-             (.terminated, .terminated):
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 public struct RxAppState {

--- a/Pod/Classes/UIViewController+Rx.swift
+++ b/Pod/Classes/UIViewController+Rx.swift
@@ -18,20 +18,6 @@ public enum ViewControllerViewState: Equatable {
     case viewDidDisappear
     case viewDidLoad
     case viewDidLayoutSubviews
-    
-    public static func ==(lhs: ViewControllerViewState, rhs: ViewControllerViewState) -> Bool {
-        switch (lhs, rhs) {
-        case (.viewDidLoad, .viewDidLoad),
-             (.viewDidLayoutSubviews, .viewDidLayoutSubviews),
-             (.viewWillAppear, .viewWillAppear),
-             (.viewDidAppear, .viewDidAppear),
-             (.viewWillDisappear, .viewWillDisappear),
-             (.viewDidDisappear, .viewDidDisappear):
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
Swift 4.1 synthesizes equatable for most common cases, just like the ones used here