### PR TITLE
fix xcode 13 error

### DIFF
--- a/Pod/Classes/UIApplication+Rx.swift
+++ b/Pod/Classes/UIApplication+Rx.swift
@@ -372,6 +372,7 @@ extension RxAppState {
     /**
      For testing purposes
      */
+    @available(iOSApplicationExtension, unavailable)
     internal static func clearSharedObservables() {
         objc_setAssociatedObject(UIApplication.shared,
                                  &_sharedRxAppStateKey,


### PR DESCRIPTION
Xcode 13 requires methods that access specific UIApplication APIs to be annotated with proper iOSApplicationExtension availability.