### PR TITLE
Add `viewIsAppearing` to viewStates

### DIFF
--- a/Pod/Classes/UIViewController+Rx.swift
+++ b/Pod/Classes/UIViewController+Rx.swift
@@ -19,6 +19,9 @@ public enum ViewControllerViewState: Equatable {
     case viewDidDisappear
     case viewDidLoad
     case viewDidLayoutSubviews
+    
+    @available(iOS 13.0, *)
+    case viewIsAppearing
 }
 
 /**
@@ -39,6 +42,12 @@ extension RxSwift.Reactive where Base: UIViewController {
     
     public var viewWillAppear: Observable<Bool> {
         return methodInvoked(#selector(UIViewController.viewWillAppear))
+            .map { $0.first as? Bool ?? false }
+    }
+    
+    @available(iOS 13.0, *)
+    public var viewIsAppearing: Observable<Bool> {
+        return methodInvoked(#selector(UIViewController.viewIsAppearing))
             .map { $0.first as? Bool ?? false }
     }
     
@@ -65,14 +74,29 @@ extension RxSwift.Reactive where Base: UIViewController {
      - returns: Observable sequence of AppStates
      */
     public var viewState: Observable<ViewControllerViewState> {
-        return Observable.of(
-            viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
-            viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
-            viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
-            viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
-            viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
-            viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear }
-            )
-            .merge()
+        if #available(iOS 13.0, *) {
+            Observable.of(
+                viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
+                viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
+                viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
+                viewIsAppearing.map {_ in return ViewControllerViewState.viewWillAppear },
+                viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
+                viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
+                viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear },
+                viewIsAppearing.map { _ in return ViewControllerViewState.viewIsAppearing }
+                )
+                .merge()
+        } else {
+            Observable.of(
+                viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
+                viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
+                viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
+                viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
+                viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
+                viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear }
+                )
+                .merge()
+        }
+        
     }
 }

--- a/Pod/Classes/UIViewController+Rx.swift
+++ b/Pod/Classes/UIViewController+Rx.swift
@@ -74,29 +74,23 @@ extension RxSwift.Reactive where Base: UIViewController {
      - returns: Observable sequence of AppStates
      */
     public var viewState: Observable<ViewControllerViewState> {
+        var viewControllerStates: [Observable<ViewControllerViewState>] = [
+            viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
+            viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
+            viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
+            viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
+            viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
+            viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear }
+        ]
+        
         if #available(iOS 13.0, *) {
-            Observable.of(
-                viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
-                viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
-                viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
-                viewIsAppearing.map {_ in return ViewControllerViewState.viewWillAppear },
-                viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
-                viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
-                viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear },
+            viewControllerStates.append(
                 viewIsAppearing.map { _ in return ViewControllerViewState.viewIsAppearing }
-                )
-                .merge()
-        } else {
-            Observable.of(
-                viewDidLoad.map {_ in return ViewControllerViewState.viewDidLoad },
-                viewDidLayoutSubviews.map {_ in return ViewControllerViewState.viewDidLayoutSubviews },
-                viewWillAppear.map {_ in return ViewControllerViewState.viewWillAppear },
-                viewDidAppear.map {_ in return ViewControllerViewState.viewDidAppear },
-                viewWillDisappear.map {_ in return ViewControllerViewState.viewWillDisappear },
-                viewDidDisappear.map {_ in return ViewControllerViewState.viewDidDisappear }
-                )
-                .merge()
+            )
         }
         
+        return Observable
+            .from(viewControllerStates)
+            .merge()
     }
 }


### PR DESCRIPTION
As Apple has implemented `viewIsAppearing` this year(2023), I am adding it to viewState for easier use.

[Documentation](https://developer.apple.com/documentation/uikit/uiviewcontroller/4195485-viewisappearing)
[WWDC Video](https://developer.apple.com/videos/play/wwdc2023/10055/?time=128)

As it is backported to iOS 13 only, `@available` attribute is added to the property.

Please feel free to comment if there are any suggestions/code improvements, thanks.